### PR TITLE
feat(userconfig): added option to export userconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ jobs:
           token: ${{ secrets.my-personal-access-token }}
           scope: ${{ github.repository_owner }}
           path: ${{ github.workspace }}/.npmrc
+          export_user_config: 'true'
 ```
 
 ### Inputs
 
-| input | required | default                          | description                                                             |
-|-------|----------|----------------------------------|-------------------------------------------------------------------------|
-| token | ❌        | `${{ github.token }}`            | the token to use with npm cli                                           |
-| scope | ❌        | `${{ github.repository_owner }}` | the "npm scope", typically this will be your GitHub username / org name |
-| path  | ❌        | `${{ github.workspace }}/.npmrc` | where to store the `.npmrc` file                                        |
+| input               | required | default                          | description                                                             |
+|---------------------|----------|----------------------------------|-------------------------------------------------------------------------|
+| token               | ❌        | `${{ github.token }}`            | the token to use with npm cli                                           |
+| scope               | ❌        | `${{ github.repository_owner }}` | the "npm scope", typically this will be your GitHub username / org name |
+| path                | ❌        | `${{ github.workspace }}/.npmrc` | where to store the `.npmrc` file                                        |
+| export_user_config  | ❌        | `false`                          | export the path to `.npmrc` as `NPM_CONFIG_USERCONFIG`                  |
 
 > ***Note**: your github token should have the [appropriate scopes](https://docs.github.com/en/packages/guides/about-github-container-registry#about-scopes-and-permissions-for-github-container-registry)*
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 inputs:
   path:
     description: path to write .npmrc file
-    default: ${{ github.workspace	}}/.npmrc
+    default: ${{ github.workspace }}/.npmrc
 
   scope:
     description: the github owner / org name to proxy through
@@ -18,6 +18,11 @@ inputs:
     description: github token to use with npm
     default: ${{ github.token }}
 
+  export_user_config:
+    description: export the path to .npmrc as NPM_CONFIG_USERCONFIG
+    default: 'false'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -26,3 +31,8 @@ runs:
         npm config --userconfig "${{ inputs.path }}" set registry="https://npm.pkg.github.com/${{ inputs.scope }}"
         npm config --userconfig "${{ inputs.path }}" set //npm.pkg.github.com/:_authToken "${{ inputs.token }}"
         npm config --userconfig "${{ inputs.path }}" set always-auth true
+
+        if [ "${{ inputs.export_user_config }}" != "false" ]; then
+          echo "NPM_CONFIG_USERCONFIG=${{ inputs.path }}" >> $GITHUB_ENV
+        fi
+


### PR DESCRIPTION
Added option to export `NPM_CONFIG_USERCONFIG` as path to `.npmrc` to Github Env. (https://docs.npmjs.com/cli/v6/using-npm/config#npmrc-files)

Edit: GHA only allow string types, so the boolean check is done with an input != "false" so anything other than 'false' would cause the action to export the environment. 