### PR TITLE
feat(always_auth): remove always auth as default flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
 | path                 | ❌        | `${{ github.workspace }}/.npmrc` | where to store the `.npmrc` file                                        |
 | export\_user\_config | ❌        | `false`                          | export the path to `.npmrc` as `NPM_CONFIG_USERCONFIG`                  |
 | proxy                | ❌        | `false`                          | enable the GitHub npm packages proxy for npm                            |
+| always\_auth         | ❌        | `false`                          | set `always-auth true` flag                                             |
 
 > ***Note**: your github token should have the [appropriate scopes][]*
 

--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,21 @@ inputs:
     default: 'false'
     required: false
 
+  always_auth:
+    description: set the always-auth flag to true
+    default: 'false'
+    required: false
+
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
         npm config --userconfig "${{ inputs.path }}" set //npm.pkg.github.com/:_authToken "${{ inputs.token }}"
-        npm config --userconfig "${{ inputs.path }}" set always-auth true
+
+        if [ "${{ input.always_auth" == "true" ]; then
+          npm config --userconfig "${{ inputs.path }}" set always-auth true
+        fi
 
         if [ "${{ inputs.proxy }}" != "true" ]; then
           npm config --userconfig "${{ inputs.path }}" set @${{ inputs.scope }}:registry="https://npm.pkg.github.com"


### PR DESCRIPTION
BREAKING CHANGE: always_auth is set to false, and will be removed as the default value set with `npm config` this is due to the option being removed in npm v9

For older versions of npm, setting `always_auth: true` will enable this flag again