### PR TITLE
fix: remove always-auth (gone since npm v7.11.1)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,6 @@ runs:
     - shell: bash
       run: |
         npm config --userconfig "${{ inputs.path }}" set //npm.pkg.github.com/:_authToken "${{ inputs.token }}"
-        npm config --userconfig "${{ inputs.path }}" set always-auth true
 
         if [ "${{ inputs.proxy }}" != "true" ]; then
           npm config --userconfig "${{ inputs.path }}" set @${{ inputs.scope }}:registry="https://npm.pkg.github.com"


### PR DESCRIPTION
`always-auth` is gone with npm v7.11.1 ([here](https://github.com/npm/cli/compare/v7.11.0...v7.11.1#diff-39d84a583762ad8e04f647a309ed03c6b21c87b39c14ac1349484040bc79011eL61))

Could we possibly remove it?

Screenshot with error blocking our workflows attached.

<img width="1312" alt="Screen Shot 2023-02-10 at 12 21 31 PM" src="https://user-images.githubusercontent.com/11021586/218190707-d472de30-0980-4c5f-b046-d6f983eff3a8.png">
